### PR TITLE
Added support for bools; alternate datetime syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -496,16 +496,24 @@ function propertyToPostgres(property, name, schema, isAlter) {
     case 'text':
       column = 'TEXT';
       break;
+    case 'boolean':
+      column = 'BOOLEAN';
+      break;
     case 'blob':
       column = 'BYTEA';
       break;
     case 'string':
-      if (property.maxLength) {
-        column = 'VARCHAR(' + property.maxLength + ')';
+      if (property.format=='date-time') {
+        property.type = 'datetime';
+        // Fall through
       } else {
-        column = 'TEXT';
+        if (property.maxLength) {
+          column = 'VARCHAR(' + property.maxLength + ')';
+        } else {
+          column = 'TEXT';
+        }
+        break;
       }
-      break;
     case 'date':
       column = 'DATE';
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -504,16 +504,15 @@ function propertyToPostgres(property, name, schema, isAlter) {
       break;
     case 'string':
       if (property.format=='date-time') {
-        property.type = 'datetime';
-        // Fall through
+        column = 'TIMESTAMPTZ';
       } else {
         if (property.maxLength) {
           column = 'VARCHAR(' + property.maxLength + ')';
         } else {
           column = 'TEXT';
         }
-        break;
       }
+      break;
     case 'date':
       column = 'DATE';
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,7 @@ function propertyToPostgres(property, name, schema, isAlter) {
       column = 'BYTEA';
       break;
     case 'string':
-      if (property.format=='date-time') {
+      if (property.format === 'date-time') {
         column = 'TIMESTAMPTZ';
       } else {
         if (property.maxLength) {


### PR DESCRIPTION
Postgres supports booleans, so added that; JSONSchema also often handles datetime with 
{ type: 'string', format: 'date-time' } so added logic to deal with that.