### PR TITLE
Added support for bigint in postgres

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ function jsonSchemaTable(tableName, schema, config) {
     dialect.propertyToDb = propertyToMssql;
   } else {
     dialect.propertyToDb = propertyToPostgres;
+    dialect.bigint = !!config.bigint;
   }
   return {
     create: function() {
@@ -485,12 +486,14 @@ function mssqlToProperty(metadata) {
 
 function propertyToPostgres(property, name, schema, isAlter) {
   var column;
+  var integerType = (property.bigint ? 'BIGINT' : 'INTEGER');
+
   switch (property.type) {
     case 'integer':
       if (property.autoIncrement === true) {
         column = 'SERIAL';
       } else {
-        column = 'INTEGER';
+        column = integerType;
       }
       break;
     case 'text':
@@ -532,7 +535,7 @@ function propertyToPostgres(property, name, schema, isAlter) {
       if (property.decimals && property.decimals > 0) {
         column = 'NUMERIC(' + property.maxLength + ',' + property.decimals + ')';
       } else {
-        column = 'INTEGER';
+        column = integerType;
       }
       break;
     case 'object':

--- a/src/index.js
+++ b/src/index.js
@@ -486,7 +486,7 @@ function mssqlToProperty(metadata) {
 
 function propertyToPostgres(property, name, schema, isAlter) {
   var column;
-  var integerType = (property.bigint ? 'BIGINT' : 'INTEGER');
+  var integerType = (this.bigint ? 'BIGINT' : 'INTEGER');
 
   switch (property.type) {
     case 'integer':


### PR DESCRIPTION
For certain data sets, it's desirable to use 64 bit integers; this allows the user to specify BIGINT when creating a postgres schema.