### PR TITLE
Numeric to float

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -535,7 +535,7 @@ function propertyToPostgres(property, name, schema, isAlter) {
       if (property.decimals && property.decimals > 0) {
         column = 'NUMERIC(' + property.maxLength + ',' + property.decimals + ')';
       } else {
-        column = integerType;
+        column = 'REAL';
       }
       break;
     case 'object':

--- a/src/index.js
+++ b/src/index.js
@@ -536,6 +536,8 @@ function propertyToPostgres(property, name, schema, isAlter) {
     case 'number':
       if (property.decimals && property.decimals > 0) {
         column = 'NUMERIC(' + property.maxLength + ',' + property.decimals + ')';
+      } else if (property.maxLength > 0) {
+        column = integerType;
       } else {
         column = floatType;
       }
@@ -583,7 +585,7 @@ function postgresToProperty(metadata) {
       break;
     case 'real':
     case 'double precision':
-      property.type = 'numeric';
+      property.type = 'number';
       break;
     case 'time':
       property.type = 'time';

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ function jsonSchemaTable(tableName, schema, config) {
   } else {
     dialect.propertyToDb = propertyToPostgres;
     dialect.bigint = !!config.bigint;
+    dialect.doubleFloats = !!config.doubleFloats;
   }
   return {
     create: function() {
@@ -487,6 +488,7 @@ function mssqlToProperty(metadata) {
 function propertyToPostgres(property, name, schema, isAlter) {
   var column;
   var integerType = this.bigint ? 'BIGINT' : 'INTEGER';
+  var floatType = this.doubleFloats ? 'DOUBLE PRECISION' : 'REAL';
 
   switch (property.type) {
     case 'integer':
@@ -535,7 +537,7 @@ function propertyToPostgres(property, name, schema, isAlter) {
       if (property.decimals && property.decimals > 0) {
         column = 'NUMERIC(' + property.maxLength + ',' + property.decimals + ')';
       } else {
-        column = 'DOUBLE PRECISION';
+        column = floatType;
       }
       break;
     case 'object':
@@ -571,9 +573,17 @@ function postgresToProperty(metadata) {
   var property = {name: metadata.column_name};
   switch (metadata.data_type) {
     case 'integer':
+    case 'boolean':
     case 'text':
     case 'date':
       property.type = metadata.data_type;
+      break;
+    case 'bigint':
+      property.type = 'integer';
+      break;
+    case 'real':
+    case 'double precision':
+      property.type = 'numeric';
       break;
     case 'time':
       property.type = 'time';

--- a/src/index.js
+++ b/src/index.js
@@ -535,7 +535,7 @@ function propertyToPostgres(property, name, schema, isAlter) {
       if (property.decimals && property.decimals > 0) {
         column = 'NUMERIC(' + property.maxLength + ',' + property.decimals + ')';
       } else {
-        column = 'REAL';
+        column = 'DOUBLE PRECISION';
       }
       break;
     case 'object':


### PR DESCRIPTION
Given that jsonschema has both "numeric" and "integer" types, I think that numeric types with no fixed point specifications should be floating point types in the database.

Happy to flesh this out to mysql as well; did postgres here because that's the db I know and the one I work with.